### PR TITLE
fix: include padding in auto mode image export dimensions

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>winshot-temp</title>
-  <script type="module" crossorigin src="/assets/index.fe0188a7.js"></script>
+  <script type="module" crossorigin src="/assets/index.08f2fd80.js"></script>
   <link rel="stylesheet" href="/assets/index.03925d07.css">
 </head>
 <body>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -83,7 +83,13 @@ function calculateOutputDimensions(
   const targetRatio = parseRatio(outputRatio);
 
   if (targetRatio === null) {
-    // Auto mode: output size same as screenshot dimensions
+    // Auto mode: include padding if set, otherwise raw screenshot size
+    if (padding > 0) {
+      return {
+        totalWidth: screenshotWidth + padding * 2,
+        totalHeight: screenshotHeight + padding * 2
+      };
+    }
     return { totalWidth: screenshotWidth, totalHeight: screenshotHeight };
   }
 


### PR DESCRIPTION
Fixed image cropping issue when using Copy, Quick Save, or Save As operations. The calculateOutputDimensions function in App.tsx was not including padding in auto mode, causing exported images to be smaller than displayed on screen.