### PR TITLE
fix(release): sync package.json version with releases

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -43,6 +43,12 @@
       }
     ],
     [
+      "@semantic-release/npm",
+      {
+        "npmPublish": false
+      }
+    ],
+    [
       "@semantic-release/git",
       {
         "assets": ["CHANGELOG.md", "package.json"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.4.0](https://github.com/mrgoonie/winshot/compare/v1.3.0...v1.4.0) (2025-12-24)
+
+
+### Features
+
+* **annotation:** implement tapered arrow shapes with curve support ([363f471](https://github.com/mrgoonie/winshot/commit/363f471fb826e808801b712435bc1c32dae78429))
+
 # [1.3.0](https://github.com/mrgoonie/winshot/compare/v1.2.0...v1.3.0) (2025-12-24)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winshot",
-  "version": "1.2.0-beta.3",
+  "version": "1.4.0",
   "private": true,
   "description": "Modern Screenshot Tool for Windows",
   "repository": {


### PR DESCRIPTION
## Summary
- Add `@semantic-release/npm` plugin to update package.json version during releases
- Sync package.json version to 1.4.0

## Changes
- `.releaserc.json`: Added `@semantic-release/npm` with `npmPublish: false`
- `package.json`: Updated version from 1.2.0-beta.3 to 1.4.0