### PR TITLE
Add handling of digit and letter shortcuts by their code

### DIFF
--- a/frontend/src/components/hotkey-input.tsx
+++ b/frontend/src/components/hotkey-input.tsx
@@ -70,9 +70,10 @@ export function HotkeyInput({ value, onChange, label, disabled = false }: Hotkey
     // Map special keys
     if (keyCodeToName[e.code]) {
       keyName = keyCodeToName[e.code];
-    } else if (e.key.length === 1) {
-      // Single character (letter or number)
-      keyName = e.key.toUpperCase();
+    } else if (e.code.startsWith("Digit")) {
+      keyName = e.code.slice(5);
+    } else if (e.code.startsWith("Key")) {
+      keyName = e.code.slice(3);
     }
 
     parts.push(keyName);


### PR DESCRIPTION
Hello.

I'm not very experienced developer, but do you think using of `e.key` code for handling hotkeys is a good idea?
So far I encountered some issues because of this.

For example, when I want to set `Ctrl+Shift+2` shortcut, it is recognized as a `Ctrl+Shift+@` and doesn't work.
And other keyboard language layouts might set wrong characters.

<img width="240" height="auto" alt="Image" src="https://github.com/user-attachments/assets/bd2a9069-a0f8-4e3b-9a7c-47f600f2fb7b" />

I made a small change, that uses `e.code` (not `e.key`) to handle shortcuts.
And shortcuts like `Ctrl+Shift+2` started working.

<img width="240" height="auto" alt="Image" src="https://github.com/user-attachments/assets/d9c4efe1-5cb5-47eb-b367-76c5b86f07d7" />

And I was wondering, maybe it would be better to only use `e.code` in when handling hotkeys?
What do you think?