### PR TITLE
feat(shape): persist rectangle corner radius setting

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -234,6 +234,7 @@ function App() {
           if (cfg.inset !== undefined) setInset(cfg.inset);
           if (cfg.autoBackground !== undefined) setAutoBackground(cfg.autoBackground);
           if (cfg.insetBackgroundColor) setInsetBackgroundColor(cfg.insetBackgroundColor);
+          if (cfg.shapeCornerRadius !== undefined) setShapeCornerRadius(cfg.shapeCornerRadius);
         }
       } catch (err) {
         console.error('Failed to load editor settings:', err);
@@ -256,10 +257,11 @@ function App() {
       inset,
       autoBackground,
       insetBackgroundColor: insetBackgroundColor || undefined,
+      shapeCornerRadius,
     }).catch(err => {
       console.error('Failed to save editor settings:', err);
     });
-  }, [padding, cornerRadius, shadowSize, backgroundColor, outputRatio, showBackground, inset, autoBackground, insetBackgroundColor, editorSettingsLoaded]);
+  }, [padding, cornerRadius, shadowSize, backgroundColor, outputRatio, showBackground, inset, autoBackground, insetBackgroundColor, shapeCornerRadius, editorSettingsLoaded]);
 
   // Load export settings from config on startup
   useEffect(() => {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -86,11 +86,12 @@ export namespace config {
 	    inset: number;
 	    autoBackground: boolean;
 	    insetBackgroundColor?: string;
-	
+	    shapeCornerRadius: number;
+
 	    static createFrom(source: any = {}) {
 	        return new EditorConfig(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.padding = source["padding"];
@@ -102,6 +103,7 @@ export namespace config {
 	        this.inset = source["inset"];
 	        this.autoBackground = source["autoBackground"];
 	        this.insetBackgroundColor = source["insetBackgroundColor"];
+	        this.shapeCornerRadius = source["shapeCornerRadius"];
 	    }
 	}
 	export class WindowConfig {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,7 @@ type EditorConfig struct {
 	Inset                int    `json:"inset"`                          // 0-50 percentage for screenshot scaling
 	AutoBackground       bool   `json:"autoBackground"`                 // Auto-extract edge color for background
 	InsetBackgroundColor string `json:"insetBackgroundColor,omitempty"` // Custom inset background color
+	ShapeCornerRadius    int    `json:"shapeCornerRadius"`              // Default corner radius for rectangle annotations (0-50)
 }
 
 // R2Config holds Cloudflare R2 settings (secrets stored in Credential Manager)
@@ -124,14 +125,15 @@ func Default() *Config {
 			Height: 800,
 		},
 		Editor: EditorConfig{
-			Padding:         40,
-			CornerRadius:    12,
-			ShadowSize:      20,
-			BackgroundColor: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
-			OutputRatio:     "auto",
-			ShowBackground:  true,
-			Inset:           0,
-			AutoBackground:  true,
+			Padding:           40,
+			CornerRadius:      12,
+			ShadowSize:        20,
+			BackgroundColor:   "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
+			OutputRatio:       "auto",
+			ShowBackground:    true,
+			Inset:             0,
+			AutoBackground:    true,
+			ShapeCornerRadius: 0,
 		},
 		Update: UpdateConfig{
 			CheckOnStartup: true,


### PR DESCRIPTION
## Summary

- Add persistence for rectangle annotation corner radius setting
- Setting is now saved to config and restored on app startup

## Changes

- `internal/config/config.go`: Added `ShapeCornerRadius` field to `EditorConfig` struct
- `frontend/wailsjs/go/models.ts`: Updated TypeScript EditorConfig class with new field
- `frontend/src/App.tsx`: Load and save `shapeCornerRadius` from/to config

## Test plan

- [ ] Open app and draw a rectangle with custom corner radius
- [ ] Close and reopen app
- [ ] Verify corner radius setting is preserved